### PR TITLE
IMDSSample.sh: use curl instead of wget

### DIFF
--- a/IMDSSample.sh
+++ b/IMDSSample.sh
@@ -12,7 +12,7 @@ openssl pkcs7 -in decodedsignature -inform DER -out sign.pk7
 # Get Public key out of pkc7
 openssl pkcs7 -in decodedsignature -inform DER  -print_certs -out signer.pem
 #Get the intermediate certificate
-wget -q -O intermediate.cer "$(openssl x509 -in signer.pem -text -noout | grep " CA Issuers -" | awk -FURI: '{print $2}')"
+curl -so intermediate.cer "$(openssl x509 -in signer.pem -text -noout | grep " CA Issuers -" | awk -FURI: '{print $2}')"
 openssl x509 -inform der -in intermediate.cer -out intermediate.pem
 #Verify the contents
 openssl smime -verify -in sign.pk7 -inform pem -noverify


### PR DESCRIPTION
Microsoft/Akamai seems to reject any request with "Wget" in the
user-agent.

```
wget -O /dev/null 'http://www.microsoft.com/pki/mscorp/Microsoft%20RSA%20TLS%20CA%2001.crt'
[...]
2021-07-20 10:02:36 ERROR 403: Forbidden.
```

But when changing the user agent, it works fine:

```
wget -U 'Foo' -O /dev/null 'http://www.microsoft.com/pki/mscorp/Microsoft%20RSA%20TLS%20CA%2001.crt'
[...]
HTTP request sent, awaiting response... 200 OK
```

Instead of passing a custom user-agent to wget, simply replace wget by
curl (which is installed as part of this script).