### PR TITLE
Update IMDS API version from 2021-02-01 to 2023-07-01 

### DIFF
--- a/IMDSSample-windows.cpp
+++ b/IMDSSample-windows.cpp
@@ -173,7 +173,7 @@ void GetMetadata(LPCWSTR serverName, WORD port, LPCWSTR url)
 
 int wmain(int argc, PCWSTR argv[])
 {
-    GetMetadata(L"169.254.169.254", 80, L"metadata/instance?api-version=2021-02-01");
+    GetMetadata(L"169.254.169.254", 80, L"metadata/instance?api-version=2023-07-01");
 
     return 0;
 }

--- a/IMDSSample.cs
+++ b/IMDSSample.cs
@@ -96,13 +96,13 @@ namespace Samples
 
         private static Task<string> QueryInstanceEndpoint()
         {
-            return QueryImds(InstanceEndpoint, "2021-02-01");
+            return QueryImds(InstanceEndpoint, "2023-07-01");
         }
 
         private static Task<string> QueryAttestedEndpoint()
         {
             string nonce = "nonce=" + NonceValue;
-            return QueryImds(AttestedEndpoint, "2021-02-01", nonce);
+            return QueryImds(AttestedEndpoint, "2023-07-01", nonce);
         }
 
         // Query IMDS server and retrieve JSON result

--- a/IMDSSample.js
+++ b/IMDSSample.js
@@ -4,7 +4,7 @@ var http = require('http');
 
 function JsonQueryIMDS(path, callback) 
 {
-    api_version = '2021-02-01';
+    api_version = '2023-07-01';
     imds_server = '169.254.169.254';
 
     result = ''  

--- a/IMDSSample.pl
+++ b/IMDSSample.pl
@@ -7,7 +7,7 @@ use HTTP::Tiny;
 use JSON;
 use Data::Dumper;
 
-my $md_url = 'http://169.254.169.254/metadata/instance?api-version=2021-02-01';
+my $md_url = 'http://169.254.169.254/metadata/instance?api-version=2023-07-01';
 my $headers = { Metadata => 'true' };
 
 # Proxies must be bypassed when calling Azure IMDS

--- a/IMDSSample.ps1
+++ b/IMDSSample.ps1
@@ -20,14 +20,14 @@ $NonceValue = "123456"
 
 function Query-InstanceEndpoint
 {
-    $uri = $InstanceEndpoint + "?api-version=2021-02-01"
+    $uri = $InstanceEndpoint + "?api-version=2023-07-01"
     $result = Invoke-RestMethod -Method GET -NoProxy -Uri $uri -Headers @{"Metadata"="True"}
     return $result
 }
 
 function Query-AttestedEndpoint
 {
-    $uri = $AttestedEndpoint + "?api-version=2021-02-01&nonce=" + $NonceValue
+    $uri = $AttestedEndpoint + "?api-version=2023-07-01&nonce=" + $NonceValue
     $result = Invoke-RestMethod -Method GET -NoProxy -Uri $uri -Headers @{"Metadata"="True"}
     return $result
 }

--- a/IMDSSample.py
+++ b/IMDSSample.py
@@ -9,11 +9,11 @@ import requests
 
 imds_server_base_url = "http://169.254.169.254"
 
-instance_api_version = "2021-02-01"
+instance_api_version = "2023-07-01"
 instance_endpoint = imds_server_base_url + \
     "/metadata/instance?api-version=" + instance_api_version
 
-attested_api_version = "2021-02-01"
+attested_api_version = "2023-07-01"
 attested_nonce = "1234576"
 attested_endpoint = imds_server_base_url + "/metadata/attested/document?api-version=" + \
     attested_api_version + "&nonce=" + attested_nonce

--- a/IMDSSample.rb
+++ b/IMDSSample.rb
@@ -1,7 +1,7 @@
 require 'open-uri'
 require 'json'
 
-url_metadata="http://169.254.169.254/metadata/instance?api-version=2021-02-01"
+url_metadata="http://169.254.169.254/metadata/instance?api-version=2023-07-01"
 
 # Proxies must be bypassed when calling Azure IMDS
 puts open(url_metadata,"Metadata"=>"true", :proxy => nil).read

--- a/IMDSSample.sh
+++ b/IMDSSample.sh
@@ -2,9 +2,9 @@ sudo apt-get install curl
 sudo apt-get install jq
 # NOTE: Proxies must be bypassed using the --noproxy flag when calling Azure IMDS
 # Instance call
-curl -H Metadata:True --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01&format=json" | jq .
+curl -H Metadata:True --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2023-07-01&format=json" | jq .
 # Make Attested call and extract signature
-curl  --silent -H Metadata:True --noproxy "*" http://169.254.169.254/metadata/attested/document?api-version=2021-02-01 | jq -r '.["signature"]' > signature
+curl  --silent -H Metadata:True --noproxy "*" http://169.254.169.254/metadata/attested/document?api-version=2023-07-01 | jq -r '.["signature"]' > signature
 # Decode the signature
 base64 -d signature > decodedsignature
 #Get PKCS7 format

--- a/IMDSSample.vb
+++ b/IMDSSample.vb
@@ -5,7 +5,7 @@ Imports Newtonsoft.Json
 Module Module1
 
     Sub Main()
-        Dim request As HttpWebRequest = WebRequest.Create("http://169.254.169.254/metadata/instance?api-version=2021-02-01")
+        Dim request As HttpWebRequest = WebRequest.Create("http://169.254.169.254/metadata/instance?api-version=2023-07-01")
         ' IMDS requires proxies to be bypassed
         Dim proxy As New WebProxy()
         request.Headers.Add("Metadata: True")

--- a/imdssample.go
+++ b/imdssample.go
@@ -16,7 +16,7 @@ func main() {
 
     q := req.URL.Query()
     q.Add("format", "json")
-    q.Add("api-version", "2021-02-01")
+    q.Add("api-version", "2023-07-01")
     req.URL.RawQuery = q.Encode()
 
     resp, err := client.Do(req)

--- a/imdssample.java
+++ b/imdssample.java
@@ -99,13 +99,13 @@ public class IMDSSample
     
     private static String QueryInstanceEndpoint()
     {
-        return QueryImds(InstanceEndpoint, "2021-02-01");       
+        return QueryImds(InstanceEndpoint, "2023-07-01");       
     }
     
     private static String QueryAttestedEndpoint()
     {
         String nonce = "nonce=" + NonceValue;
-        return QueryImds(AttestedEndpoint, "2021-02-01", nonce);
+        return QueryImds(AttestedEndpoint, "2023-07-01", nonce);
     }
     
     private static String QueryImds(String path, String apiVersion)


### PR DESCRIPTION
Update IMDS API version from 2021-02-01 to 2023-07-01

- Updated Azure Instance Metadata Service API version across all sample files
- Changed from 2021-02-01 to 2023-07-01 version
- Updated samples in C++, C#, Go, Java, JavaScript, Perl, PowerShell, Python, Ruby, Shell, and VB.NET